### PR TITLE
Fixed bugs in hreaded zaps and comments

### DIFF
--- a/src/routes/stacks/[naddr]/+page.svelte
+++ b/src/routes/stacks/[naddr]/+page.svelte
@@ -312,12 +312,13 @@
     emojiTags: { shortcode: string; url: string }[];
     mentions: string[];
     parentId?: string;
+    replyToPubkey?: string;
     rootPubkey?: string;
     parentKind?: number;
   }) {
     const userPubkey = getCurrentPubkey();
     if (!userPubkey || !stack) return;
-    const { text, emojiTags: submitEmojiTags, parentId, rootPubkey, parentKind } = event;
+    const { text, emojiTags: submitEmojiTags, parentId, replyToPubkey, rootPubkey, parentKind } = event;
     const tempId = `pending-${Date.now()}`;
     const optimistic: (ReturnType<typeof parseComment> & { pending?: boolean; npub?: string }) = {
       id: tempId,
@@ -339,7 +340,7 @@
         signEvent as (t: import("nostr-tools").EventTemplate) => Promise<import("nostr-tools").NostrEvent>,
         submitEmojiTags,
         parentId,
-        rootPubkey,
+        replyToPubkey ?? rootPubkey,
         parentKind
       );
       const parsed = parseComment(signed) as ReturnType<typeof parseComment> & { npub?: string };


### PR DESCRIPTION
- Introduced `ThreadZapItem` interface in `RootComment.svelte` to support zaps in comment threads.
- Updated `Props` in `RootComment.svelte` to include `threadZaps` for managing zaps related to comments.
- Enhanced `SocialTabs.svelte` to filter and count zaps associated with main events and comments.
- Improved `fetchZaps` function in `service.ts` to handle zaps on specific events and maintain app context.
- Added support for zaps on zaps with `zappedEventId` in zap receipts.
- Refined loading logic in `+page.svelte` for comments and zaps to ensure proper merging and hydration of profiles.