### PR TITLE
Add llms.txt for AI agent discovery

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -10,6 +10,7 @@
 - [NIP-01: Basic protocol](https://raw.githubusercontent.com/nostr-protocol/nips/refs/heads/master/01.md)
 - [NIP-57: Lightning Zaps](https://raw.githubusercontent.com/nostr-protocol/nips/refs/heads/master/57.md)
 - [NIP-47: Nostr Wallet Connect](https://raw.githubusercontent.com/nostr-protocol/nips/refs/heads/master/47.md)
+- [NIP-50: Search](https://raw.githubusercontent.com/nostr-protocol/nips/refs/heads/master/50.md)
 
 ## Relay
 
@@ -134,6 +135,23 @@ zsp publish -r github.com/your-org/your-app
 ```
 
 The wizard creates a `zapstore.yaml` config. Commit it to your repo for automatic relay whitelisting.
+
+### Example `zapstore.yaml`
+
+```yaml
+name: Amethyst
+description: The all-in-one Nostr client
+license: MIT
+builder: npub142gywvjkq0dv6nupggyn2euhx4nduwc7yz5f24ah9rpmunr2s39se3xrj0
+repository: https://github.com/vitorpamplona/amethyst
+homepage: https://amethyst.social/
+assets:
+  - amethyst-googleplay.*.apk
+remote_metadata:
+  - github
+```
+
+Real examples: [Amethyst](https://github.com/vitorpamplona/amethyst/blob/main/zapstore.yaml), [Nostrmo](https://github.com/haorendashu/nostrmo/blob/main/zapstore.yaml)
 
 ### Signing
 


### PR DESCRIPTION
## Summary

Adds a `/llms.txt` file to `zapstore.dev` — a machine-readable markdown description of Zapstore for AI agents and coding assistants.

## What's in it

- What Zapstore is (one paragraph)
- Relay endpoint (`wss://relay.zapstore.dev`)
- All event kinds with purpose descriptions (32267, 30063, 3063, 30509, 30267, 1111, 9735, 0)
- Full resolution chain with NIP-01 filter examples for each step (find app → get release → resolve assets → verify identity → browse curation → read reviews)
- Publishing workflow via `zsp` (wizard, direct, signing methods, metadata enrichment)
- Desktop CLI commands (`zapstore search/install/update/list/remove`)
- Payment info (NIP-57 zaps, NIP-47 NWC)
- Links to custom NIP specs and docs

## Why

When a developer asks their coding agent "how do I publish my app on Zapstore?", the agent currently has no accurate source. This file gives agents the complete picture — event kinds, filter syntax, relay endpoint, CLI commands — so they can help developers onboard.

[llms.txt spec](https://llmstxt.org/) — adopted by Anthropic, Stripe, Cloudflare, Vercel.

## Implementation

One static file at `static/llms.txt`. No code changes, no dependencies.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)