### PR TITLE
Split FAQ into developer and community FAQs

### DIFF
--- a/src/content/docs/faq.md
+++ b/src/content/docs/faq.md
@@ -1,6 +1,6 @@
 ---
 title: Developer FAQ
-description: Publishing, signing, verification, and troubleshooting for developers on Zapstore.
+description: Developer FAQ for publishing apps on Zapstore with zsp, APK signing, Nostr verification, relay publishing, and troubleshooting.
 weight: 99
 ---
 

--- a/src/content/docs/faq.md
+++ b/src/content/docs/faq.md
@@ -1,84 +1,162 @@
 ---
-title: FAQ
+title: Developer FAQ
+description: Publishing, signing, verification, and troubleshooting for developers on Zapstore.
 weight: 99
 ---
 
-## General
+Looking for install, safety, and everyday use? See the [Community FAQ](/community/faq).
+
+## Basics
 
 ### What is Zapstore?
 
-Zapstore is an open Android app store built on Nostr. Apps are discovered through your social graph, releases are cryptographically verified, and developers can receive Bitcoin payments directly from users.
+Zapstore is an open Android app store built on Nostr. Developers publish signed release metadata to relays; users discover apps, verify publishers, and install APKs from the original sources.
 
-### How is Zapstore different from Google Play?
+New to the project? Start with the [quickstart](/docs/quickstart).
 
-Zapstore has no central gatekeeper. Trust comes from cryptographic signatures, social context, and reputation instead of a single platform operator.
-Developers receive payments directly. No ads, no forced tracking, and no platform cut.
+### Who is Zapstore for?
 
-### Is Zapstore open source?
+Anyone shipping Android APKs outside Google Play: indie developers, FOSS projects, and teams that want permissionless distribution with cryptographic identity and community curation.
 
-Yes. The app and publishing tooling are open source. You can review the code on [GitHub](https://github.com/zapstore/zapstore).
+### Is Zapstore only for Nostr apps?
 
----
-
-## For Users
-
-### How do I install Zapstore?
-
-Download the APK from [zapstore.dev](/) and install it on Android (10+, arm64). You may need to allow installs from unknown sources.
-
-### How does social discovery work?
-
-Zapstore uses your Nostr social graph. While browsing, you can see usage and recommendations from people you follow, which helps surface useful apps without paid ranking systems.
-
-### Are apps on Zapstore safe?
-
-Apps are signed by developers, and signatures are verified before install, so you can confirm who published a release.
-Zapstore is still permissionless, so use normal software safety habits: check developer reputation, read community feedback, and prefer developers you trust.
-
-### How do I suggest an app for the store?
-
-Search for the full repository URL (e.g. `https://github.com/user/repo`). If the app is in the store it will be returned, otherwise search miss is recorded and the repository is queued for background indexing. The repository **must have releases with APK files**, make sure you check `/releases` or similar before requesting it. If it has valid APK releases, it should appear shortly. Otherwise it will be ignored.
-
-### How do I support developers?
-
-You can send Bitcoin directly via Lightning zaps through your Nostr identity. No separate account or payment processor is required.
+No. Many listed apps have nothing to do with Nostr. Nostr is the identity and metadata layer; the catalog is for Android apps broadly.
 
 ---
 
-## For Developers
+## Publishing
 
 ### How do I publish an app?
 
-See the [publishing guide](/docs/publish) — the interactive wizard handles source, metadata, signing, and publishing.
+Use [`zsp`](https://github.com/zapstore/zsp), the Zapstore publishing CLI. The full flow is in the [publishing guide](/docs/publish).
 
-### Do I need to pay or register?
+Typical steps:
 
-No. Publishing is free and requires no registration. You need a Nostr keypair to sign your releases. See [getting whitelisted](/docs/publish#getting-whitelisted) for how the relay verifies new developers.
+1. Install `zsp` (see the publish doc).
+2. Add `zapstore.yaml` at your repo root.
+3. Configure signing in `.env` (`SIGN_WITH` as nsec, bunker URL, NIP-07, etc.).
+4. Run `zsp publish` or `zsp publish --wizard`.
+
+Indexed apps from GitHub can also appear when users search for your repo URL, but self-publishing with your own key is the path for full publisher identity and trust signals.
+
+### Does publishing cost money?
+
+No listing fees, no revenue share, no registration fee. Users can zap you over Lightning when your profile supports it; Zapstore does not take a cut today.
+
+### How often can I push updates?
+
+As often as you like. There is no review queue or approval wait. Push a new release when you are ready; users see it after relays index the event.
+
+### Why publish on Zapstore instead of only hosting the APK?
+
+You keep direct distribution, and you gain discovery (search, stacks, community), update notifications for Zapstore users, a link between your Nostr identity and your APK signing key, and optional Lightning tips from the app page.
+
+### Can I publish an app that is already on GitHub, Play, or F-Droid?
+
+Yes. Many apps are indexed from GitHub releases or self-published with `zsp`. Play and F-Droid are separate channels; Zapstore is another distribution path, not a replacement you must choose exclusively.
+
+### What is the difference between self-published and indexed apps?
+
+**Self-published** means you (or your project) signed and published the catalog event with your Nostr key.
+
+**Indexed** means Zapstore’s indexer signed an event pointing at an APK on an upstream source (often GitHub). The APK is still downloaded from that original URL, which the app page should show.
+
+Both are valid. Self-publishing gives the strongest publisher identity; indexing helps apps appear before the developer has run `zsp`.
+
+---
+
+## Signing and trust
+
+### How does verification work?
+
+Developers sign release metadata with a Nostr key. Zapstore checks those signatures and, where available, compares APK signing certificates to declarations on the catalog (including linked identity events).
+
+On install, the client uses publisher data and OS-level certificate rules. See the [trust model](/docs/trust-model) for relay rules, rejection cases, and certificate linking (NIP-C1).
+
+### What does my Nostr key sign?
+
+Your key signs Nostr catalog events (app metadata, releases, stacks, etc.). It does not replace the APK’s Android signing certificate. Both matter: Nostr for who published the listing, Android for what can update on the device.
+
+### What happens if my app signing key changes?
+
+Android will refuse updates signed with a different key than the installed app. If you rotate keys, users may need to uninstall and reinstall, and you should update certificate linking in `zsp` so metadata matches the new APK.
+
+### How does Zapstore handle impersonation or duplicate listings?
+
+Open catalogs can have name collisions. Zapstore surfaces publisher identity, source URLs, and social trust signals. Users should compare pubkey, source, and whether the real developer self-published.
+
+If you published from the wrong key, you can delete the bad event with [NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md) and republish from the correct npub.
+
+### What relays does Zapstore use?
+
+Apps are published to Zapstore’s relay set (configurable in tooling). Clients read from those relays plus any you add. Details and rejection behavior are in the [trust model](/docs/trust-model).
+
+---
+
+## Publishing issues
+
+### My npub was rejected when publishing. What do I do?
+
+New npubs are sometimes flagged automatically. Add a `pubkey` field with your npub to `zapstore.yaml` at the repository root (committed to the repo). You should not need manual whitelisting for that case.
+
+See [getting whitelisted](/docs/publish#getting-whitelisted) for how the relay verifies developers.
 
 ### What if the relay rejects my event?
 
-See [What happens if your event is rejected](/docs/trust-model#what-happens-if-your-event-is-rejected) in the Trust model.
+Check signature, kind, required tags, APK URL, and whitelist rules. The [trust model](/docs/trust-model#what-happens-if-your-event-is-rejected) walks through common rejection reasons.
 
-### How do I receive payments?
+### I published from the wrong npub. Can I delete it?
 
-Add a Lightning address to your Nostr profile. Users can zap you in the app, and you receive 100% of each payment.
+Yes. Send a NIP-09 deletion event for the incorrect release from that pubkey, then publish again from the correct key.
+
+### My app does not appear in search. What should I check?
+
+Confirm the event reached relays, the app is not deleted, and metadata (name, package id) is correct. For GitHub indexing, ensure releases include a valid APK asset. Allow a few minutes after publish.
+
+### My APK was not detected. What should I check?
+
+Release must attach an `.apk` (or pattern your `zapstore.yaml` assets cover). Private repos need tokens configured in `zsp`. Wrong repo URL or empty releases are the usual causes.
+
+### My metadata looks wrong. How do I fix it?
+
+Republish with corrected `zapstore.yaml` and release tags. If you linked the wrong signing certificate, use `zsp identity` flows described in `zsp` release notes and the trust model doc.
+
+---
+
+## Growth and payments
+
+### How do users find my app?
+
+Search, stacks, social graph signals, deep links to your app page, and badges on your site pointing to Zapstore.
+
+### Can I add a “Get it on Zapstore” badge?
+
+Yes. Use assets and guidelines on the [assets page](/assets).
+
+### How do zaps work for developers?
+
+Add a Lightning address to your Nostr profile. Users with a wallet connected via NWC can zap from the app page. Payments go to you directly.
+
+### Can I see download or impression stats?
+
+Check current studio and docs for analytics features as they ship; this FAQ does not list every metric. Ask on developer support channels if you need something specific.
 
 ---
 
 ## Technical
 
-### What is Nostr?
+### What is Nostr’s role?
 
-Nostr is an open protocol for decentralized social networking. Zapstore uses it for identity, app metadata distribution via relays, and social features like follows and zaps.
+Identity, signed catalog events, relays, follows, and zaps. [nostr.com](https://nostr.com) explains the protocol.
 
-Learn more at [nostr.com](https://nostr.com).
+### How do I receive payments?
 
-### How does verification work?
+Lightning address on your profile; users zap in the client. No Zapstore payment processor in the middle.
 
-Developers sign releases with their Nostr key, and that signature is published with release metadata. On install, Zapstore verifies the signature against the developer pubkey.
-This confirms provenance and helps detect tampering.
+---
 
-### What relays does Zapstore use?
+## Developer support
 
-Zapstore reads from and publishes to a default relay set, and you can configure additional relays.
-Because relay infrastructure is decentralized, there is no single point of failure.
+### Where do I get help?
+
+[Developer support on Signal](/community/support) (developer group), [GitHub issues](https://github.com/zapstore/zapstore/issues), and Nostr. For end-user install and safety questions, point people to the [Community FAQ](/community/faq).

--- a/src/lib/components/faq/FaqItem.svelte
+++ b/src/lib/components/faq/FaqItem.svelte
@@ -1,6 +1,6 @@
 <script lang="js">
-	/** @type {{ question: string, answer: string }} */
-	let { question, answer } = $props();
+	/** @type {{ id: string, question: string, answer: string }} */
+	let { id, question, answer } = $props();
 
 	let detailsEl = $state(/** @type {HTMLDetailsElement | null} */ (null));
 
@@ -13,9 +13,9 @@
 	}
 </script>
 
-<details class="faq-item panel panel-gray33" bind:this={detailsEl} ontoggle={onToggle}>
+<details id={id} class="faq-item panel panel-gray33" bind:this={detailsEl} ontoggle={onToggle}>
 	<summary class="faq-q">
-		<span class="faq-q-text">{question}</span>
+		<h3 class="faq-q-heading">{question}</h3>
 		<span class="faq-chevron" aria-hidden="true">
 			<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 				<polyline points="6 9 12 15 18 9" />
@@ -31,6 +31,7 @@
 	.faq-item {
 		border-radius: 12px;
 		overflow: hidden;
+		scroll-margin-top: 5rem;
 	}
 
 	.faq-q {
@@ -51,9 +52,12 @@
 		display: none;
 	}
 
-	.faq-q-text {
+	.faq-q-heading {
 		flex: 1;
 		min-width: 0;
+		margin: 0;
+		font: inherit;
+		font-weight: 600;
 		text-align: left;
 	}
 

--- a/src/lib/components/faq/FaqItem.svelte
+++ b/src/lib/components/faq/FaqItem.svelte
@@ -1,0 +1,100 @@
+<script lang="js">
+	/** @type {{ question: string, answer: string }} */
+	let { question, answer } = $props();
+
+	let detailsEl = $state(/** @type {HTMLDetailsElement | null} */ (null));
+
+	function onToggle() {
+		if (!detailsEl) return;
+		const summary = detailsEl.querySelector('summary');
+		if (summary) {
+			summary.setAttribute('aria-expanded', detailsEl.open ? 'true' : 'false');
+		}
+	}
+</script>
+
+<details class="faq-item panel panel-gray33" bind:this={detailsEl} ontoggle={onToggle}>
+	<summary class="faq-q">
+		<span class="faq-q-text">{question}</span>
+		<span class="faq-chevron" aria-hidden="true">
+			<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<polyline points="6 9 12 15 18 9" />
+			</svg>
+		</span>
+	</summary>
+	<div class="faq-body" role="region">
+		<div class="faq-a">{@html answer}</div>
+	</div>
+</details>
+
+<style>
+	.faq-item {
+		border-radius: 12px;
+		overflow: hidden;
+	}
+
+	.faq-q {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		padding: 1rem 1.25rem;
+		cursor: pointer;
+		list-style: none;
+		font-weight: 600;
+		font-size: 0.9375rem;
+		line-height: 1.4;
+		color: var(--white);
+	}
+
+	.faq-q::-webkit-details-marker {
+		display: none;
+	}
+
+	.faq-q-text {
+		flex: 1;
+		min-width: 0;
+		text-align: left;
+	}
+
+	.faq-chevron {
+		flex-shrink: 0;
+		color: var(--white66);
+		transition: transform 0.2s ease;
+	}
+
+	.faq-item[open] .faq-chevron {
+		transform: rotate(180deg);
+	}
+
+	.faq-body {
+		padding: 0 1.25rem 1.25rem;
+	}
+
+	.faq-a {
+		font-size: 0.9375rem;
+		line-height: 1.55;
+		color: var(--white99);
+	}
+
+	.faq-a :global(p) {
+		margin: 0 0 0.75rem;
+	}
+
+	.faq-a :global(p:last-child) {
+		margin-bottom: 0;
+	}
+
+	.faq-a :global(a) {
+		color: var(--blurple, #7c6cff);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
+	.faq-a :global(code) {
+		font-size: 0.875em;
+		padding: 0.1em 0.35em;
+		border-radius: 4px;
+		background: var(--white11);
+	}
+</style>

--- a/src/lib/components/faq/FaqPage.svelte
+++ b/src/lib/components/faq/FaqPage.svelte
@@ -1,0 +1,42 @@
+<script lang="js">
+	import FaqItem from './FaqItem.svelte';
+
+	/** @type {{ sections: Array<{ id: string, label: string, items: Array<{ id: string, question: string, answer: string }> }> }} */
+	let { sections } = $props();
+</script>
+
+<div class="faq-page">
+	{#each sections as section (section.id)}
+		<section class="faq-section" aria-labelledby="faq-section-{section.id}">
+			<h2 id="faq-section-{section.id}" class="faq-section-label">{section.label}</h2>
+			<div class="faq-list">
+				{#each section.items as item (item.id)}
+					<FaqItem question={item.question} answer={item.answer} />
+				{/each}
+			</div>
+		</section>
+	{/each}
+</div>
+
+<style>
+	.faq-page {
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
+	}
+
+	.faq-section-label {
+		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--white66);
+		margin: 0 0 0.75rem;
+	}
+
+	.faq-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+</style>

--- a/src/lib/components/faq/FaqPage.svelte
+++ b/src/lib/components/faq/FaqPage.svelte
@@ -11,7 +11,7 @@
 			<h2 id="faq-section-{section.id}" class="faq-section-label">{section.label}</h2>
 			<div class="faq-list">
 				{#each section.items as item (item.id)}
-					<FaqItem question={item.question} answer={item.answer} />
+					<FaqItem id={item.id} question={item.question} answer={item.answer} />
 				{/each}
 			</div>
 		</section>

--- a/src/lib/components/layout/Footer.svelte
+++ b/src/lib/components/layout/Footer.svelte
@@ -154,7 +154,7 @@
 						<a
 							href="/community/faq"
 							class="regular14 text-muted-foreground hover:text-foreground transition-colors"
-							>User FAQ</a
+							>FAQ</a
 						>
 					</li>
 					<li>

--- a/src/lib/components/layout/Footer.svelte
+++ b/src/lib/components/layout/Footer.svelte
@@ -152,6 +152,13 @@
 				<ul class="space-y-3">
 					<li>
 						<a
+							href="/community/faq"
+							class="regular14 text-muted-foreground hover:text-foreground transition-colors"
+							>User FAQ</a
+						>
+					</li>
+					<li>
+						<a
 							href="/blog"
 							class="regular14 text-muted-foreground hover:text-foreground transition-colors"
 							>Blog</a

--- a/src/lib/data/community-faq-content.js
+++ b/src/lib/data/community-faq-content.js
@@ -1,0 +1,207 @@
+/**
+ * User-facing FAQ for /community/faq.
+ * Answers are HTML strings (trusted static content).
+ */
+
+/** @typedef {{ id: string, question: string, answer: string }} FaqItem */
+/** @typedef {{ id: string, label: string, items: FaqItem[] }} FaqSection */
+
+/** @type {FaqSection[]} */
+export const COMMUNITY_FAQ_SECTIONS = [
+	{
+		id: 'basics',
+		label: 'Basics',
+		items: [
+			{
+				id: 'what-is-zapstore',
+				question: 'What is Zapstore?',
+				answer: `<p>Zapstore is an open Android app store. You can browse apps, install APKs, keep them updated, and support developers with Bitcoin tips when the app supports it.</p>
+<p>Releases are tied to publisher identity and signatures where available, so you get more context than a random download link.</p>`
+			},
+			{
+				id: 'install',
+				question: 'How do I install Zapstore?',
+				answer: `<p>Download the APK from <a href="https://zapstore.dev">zapstore.dev</a>. Android may ask you to allow installation from unknown sources once. That is normal for apps outside Google Play.</p>
+<p>After install, open Zapstore and update it from the app when a new version is offered. Staying on a recent build avoids many catalog and update issues.</p>`
+			},
+			{
+				id: 'need-play',
+				question: 'Do I need Google Play to use Zapstore?',
+				answer: `<p>No. Zapstore installs and runs without Google Play. You use it alongside or instead of Play for the apps you choose from the catalog.</p>`
+			},
+			{
+				id: 'need-nostr',
+				question: 'Do I need a Nostr account to use Zapstore?',
+				answer: `<p>You can browse and install apps without signing in.</p>
+<p>A Nostr account (for example via Amber) unlocks backup of your app list, zapping developers, seeing recommendations from people you follow, and fuller Web of Trust signals. For most regular use, signing in is worth it.</p>`
+			}
+		]
+	},
+	{
+		id: 'trust',
+		label: 'Trust & safety',
+		items: [
+			{
+				id: 'is-safe',
+				question: "Is Zapstore safe? How do I know apps aren't malicious?",
+				answer: `<p>Every app on Zapstore is signed in the catalog, either by the developer with their Nostr identity or by the Zapstore indexer for apps sourced from GitHub. On first install, Zapstore shows who signed the listing and whether anyone in your Web of Trust follows that publisher.</p>
+<p>Android also protects updates: it refuses an update signed with a different developer certificate than the app you already have, so you cannot be silently switched to a different signer on update.</p>
+<p>Malware scanning and detailed privacy reports are on the roadmap. First installs still need your judgment, like any open store.</p>`
+			},
+			{
+				id: 'wot',
+				question: 'What is the Web of Trust (WoT) and why does it matter?',
+				answer: `<p>The Web of Trust is based on who follows whom on Nostr. Before you install an app for the first time, Zapstore can show whether people you follow also follow or endorse that app’s developer.</p>
+<p>It is not a guarantee of safety, but it is useful context compared with an anonymous APK. Zapstore does not hide apps that lack WoT signal; it warns when trust is thin. WoT on app detail pages is improving over time.</p>`
+			},
+			{
+				id: 'impersonation',
+				question: 'What if there are two apps with the same name?',
+				answer: `<p>Compare publisher identity, source links, and trust signals before installing. Android blocks updates from a different signing key than your installed app.</p>
+<p>Duplicate and impersonation handling in the catalog has improved; if you still see duplicates after an incident, try Profile → Clear local storage. If they persist, contact support.</p>`
+			},
+			{
+				id: 'stolen-key',
+				question: 'If the Zapstore signing key were stolen, would my apps be at risk?',
+				answer: `<p>Risk is concentrated on <strong>first installs</strong>, not updates. Once an app is on your phone, Android will not apply an update signed with a different APK certificate.</p>
+<p>The indexer key signs Nostr events that point at upstream URLs; APKs for indexed apps are still fetched from those original locations, which the UI should show. The team has been rotating and tightening indexer keys where needed.</p>`
+			},
+			{
+				id: 'malware-scan',
+				question: 'Does Zapstore scan apps for malware?',
+				answer: `<p>Today the model is publisher identity, source transparency, signatures, and social trust, not automated malware scanning. Richer scanning and privacy reporting may come later. Treat first installs with the same caution you would anywhere else.</p>`
+			}
+		]
+	},
+	{
+		id: 'comparisons',
+		label: 'Comparing Zapstore',
+		items: [
+			{
+				id: 'vs-play',
+				question: 'How is Zapstore different from Google Play?',
+				answer: `<p>Google Play can remove apps, enforce policy, and collect extensive user data. Developers pay to list and wait on review.</p>
+<p>Zapstore has no single gatekeeper: publishing is permissionless, and no one can remotely uninstall apps from your device. The tradeoff is less centralized malware review; Zapstore leans on developer signing, source transparency, and community trust instead.</p>`
+			},
+			{
+				id: 'vs-fdroid',
+				question: 'How is Zapstore different from F-Droid?',
+				answer: `<p>F-Droid often rebuilds apps from source on their infrastructure, which is its own trust model, and may lag behind upstream releases. F-Droid has built-in Tor support; Zapstore does not route the client through Tor yet (a relay is available over Tor; in-app Tor is planned).</p>
+<p>Zapstore distributes APKs signed by developers (or points to upstream releases), with permissionless publishing and faster release cadence when developers push.</p>`
+			},
+			{
+				id: 'vs-obtainium',
+				question: 'How is Zapstore different from Obtainium?',
+				answer: `<p>Obtainium is strong when you already have a GitHub (or similar) URL and want updates straight from that repo, including many pre-release tracks.</p>
+<p>Zapstore adds discovery, search, stacks, publisher identity, and Web of Trust on top of indexed upstream APKs. Indexed apps are pulled from the same kinds of sources as Obtainium; Zapstore adds store UX and trust signals.</p>`
+			},
+			{
+				id: 'replace-obtainium',
+				question: 'Can I completely replace Obtainium with Zapstore?',
+				answer: `<p>For stable final releases, many people use only Zapstore. For pre-releases, beta APKs, or niche repos not in the catalog, Obtainium is still a good companion. Keeping both is common until your apps and workflows are fully covered here.</p>`
+			}
+		]
+	},
+	{
+		id: 'features',
+		label: 'Features & usage',
+		items: [
+			{
+				id: 'stacks',
+				question: 'What are Stacks?',
+				answer: `<p>Stacks are curated app lists, like playlists for apps. Create a stack, share a link, and others can browse or install everything in it.</p>
+<p>Open a stack, use the menu (three dots) for Share or Copy link. Recent app versions also expose sharing from stack and app screens.</p>`
+			},
+			{
+				id: 'backup',
+				question: 'Can I back up my apps so I can restore them on a new phone?',
+				answer: `<p>With a Nostr identity, Zapstore can store your installed app list as a private encrypted Nostr event. Sign in with the same key on a new device (for example via Amber) to restore the list.</p>
+<p>Automatic sync that stays up to date with installs is in development. App data and settings inside each app are not backed up by Zapstore.</p>`
+			},
+			{
+				id: 'older-versions',
+				question: 'Can I install older versions of an app?',
+				answer: `<p>Not as a main feature yet. Pinning an older release (for compatibility with self-hosted servers, for example) is a frequent request and is in development. Track updates on GitHub or ask in support.</p>`
+			},
+			{
+				id: 'zaps',
+				question: 'Can I zap (tip) developers directly from Zapstore?',
+				answer: `<p>Yes, when the developer’s profile supports it. Connect a Lightning wallet via NWC (Alby Hub, Zeus, Minibits, and others), then zap from the app page.</p>
+<p>Failed zaps are usually wallet or NWC configuration issues. Try refreshing your connection string in the wallet app.</p>`
+			},
+			{
+				id: 'tor',
+				question: 'Does Zapstore support Tor?',
+				answer: `<p>There is a Tor-accessible Zapstore relay. The Android client does not route all traffic through Tor yet; you can use Orbot separately today. In-client Tor support will be announced when it ships.</p>`
+			},
+			{
+				id: 'ios',
+				question: 'Is iOS supported?',
+				answer: `<p>Not yet. iOS support is planned but is more complex because of Apple’s platform rules. Check project announcements for timeline updates.</p>`
+			},
+			{
+				id: 'missing-app',
+				question: "I don't see an app I want. Can I request it?",
+				answer: `<p>Paste the app’s <strong>GitHub repository URL</strong> into the Zapstore search bar and press Enter. If the repo has releases with a valid APK attached, it may be indexed in the background within a few minutes.</p>
+<p>If nothing appears, confirm releases include an APK, update Zapstore, and try again later. Developers should use the publishing CLI for a proper listing with full trust signals.</p>`
+			}
+		]
+	},
+	{
+		id: 'troubleshoot',
+		label: 'Troubleshooting',
+		items: [
+			{
+				id: 'no-longer-available',
+				question: 'An app says "no longer available." What do I do?',
+				answer: `<p>This usually means you are on an <strong>old Zapstore build</strong> that cannot read the current catalog.</p>
+<p>If Zapstore still opens: open the <strong>Updates</strong> tab and look for Zapstore there, or check the top of <strong>Discover</strong> (latest releases), open the Zapstore entry, and tap <strong>Update</strong>. On some older versions you may need to search for Zapstore and open its app page before an update appears.</p>
+<p>If other apps still show the same error or you cannot update in-app, install the latest APK from <a href="https://zapstore.dev">zapstore.dev</a>. That is the most reliable fix.</p>`
+			},
+			{
+				id: 'cert-mismatch',
+				question: 'I get a certificate mismatch or "APK signing certificate does not match" error.',
+				answer: `<p>Update Zapstore to the latest version first. Older builds had certificate extraction bugs on some Android 10 devices (fixed around 1.0.6).</p>
+<p>If it persists, the developer may have changed signing keys, or you may have installed from another source first. Treat the warning seriously unless you know why the key changed.</p>`
+			},
+			{
+				id: 'no-updates',
+				question: "I can't update my apps. Updates aren't showing up.",
+				answer: `<p>Try in order: Profile → <strong>Clear local storage</strong>; update Zapstore itself from the website if needed; restart the app; scroll through your installed feed (some versions load updates as you scroll).</p>
+<p>If it still fails, note your Zapstore version, Android version, and device when you report the issue.</p>`
+			},
+			{
+				id: 'auto-update',
+				question: "Zapstore updated an app I didn't ask it to update.",
+				answer: `<p>Zapstore does not silently auto-update apps. You may have tapped Update All, or Zapstore may offer updates for apps that were installed outside Zapstore. Excluding apps not installed via Zapstore is being improved; check GitHub issue #315 for status.</p>`
+			},
+			{
+				id: 'display-glitches',
+				question: 'I have display glitches: duplicate apps, stale counts, wrong data.',
+				answer: `<p>Go to <strong>Profile → Clear local storage</strong>. That resets Zapstore’s cache without uninstalling your apps. It fixes many duplicate entries and stale update badges.</p>`
+			}
+		]
+	},
+	{
+		id: 'about',
+		label: 'About Zapstore',
+		items: [
+			{
+				id: 'sustainable',
+				question: 'How is Zapstore financially sustainable?',
+				answer: `<p>Development has been supported by grants, including <a href="https://opensats.org/" target="_blank" rel="noopener noreferrer">OpenSats</a> and the <a href="https://hrf.org/" target="_blank" rel="noopener noreferrer">Human Rights Foundation</a>. The team is exploring sustainable models that do not compromise open, permissionless publishing. Nothing is finalized yet.</p>`
+			},
+			{
+				id: 'support-zapstore',
+				question: 'Can I support Zapstore financially?',
+				answer: `<p>You can zap us directly from the <a href="/apps/dev.zapstore.app">Zapstore app page</a>. Grant funding also supports ongoing work. Community input shapes future monetization ideas.</p>`
+			},
+			{
+				id: 'get-help',
+				question: 'How do I report a problem or get more help?',
+				answer: `<p>Join <a href="/community/support">user or developer support on Signal</a>, post on the <a href="/community/forum">forum</a> when available, or open an issue on <a href="https://github.com/zapstore/zapstore/issues" target="_blank" rel="noopener noreferrer">GitHub</a>. Include Zapstore version, Android version, device model, and what you already tried (such as clearing local storage).</p>
+<p>Publishing an app? See the <a href="/docs/faq">Developer FAQ</a>.</p>`
+			}
+		]
+	}
+];

--- a/src/lib/utils/community-faq-seo.js
+++ b/src/lib/utils/community-faq-seo.js
@@ -1,0 +1,54 @@
+/**
+ * SEO helpers for /community/faq (FAQPage JSON-LD, plain-text answers).
+ */
+
+/** @typedef {import('$lib/data/community-faq-content.js').COMMUNITY_FAQ_SECTIONS extends infer T ? T : never} FaqSections */
+
+/**
+ * Strip HTML to plain text for schema.org Answer.text (no markup).
+ * @param {string} html
+ */
+export function htmlToPlainText(html) {
+	return html
+		.replace(/<br\s*\/?>/gi, '\n')
+		.replace(/<\/p>/gi, '\n\n')
+		.replace(/<\/li>/gi, '\n')
+		.replace(/<[^>]+>/g, '')
+		.replace(/&nbsp;/g, ' ')
+		.replace(/&amp;/g, '&')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/\n{3,}/g, '\n\n')
+		.trim();
+}
+
+/**
+ * @param {FaqSections} sections
+ * @param {string} pageUrl
+ */
+export function buildCommunityFaqJsonLd(sections, pageUrl) {
+	/** @type {Array<{ '@type': 'Question', name: string, acceptedAnswer: { '@type': 'Answer', text: string } }>} */
+	const mainEntity = [];
+
+	for (const section of sections) {
+		for (const item of section.items) {
+			mainEntity.push({
+				'@type': 'Question',
+				name: item.question,
+				acceptedAnswer: {
+					'@type': 'Answer',
+					text: htmlToPlainText(item.answer)
+				}
+			});
+		}
+	}
+
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'FAQPage',
+		url: pageUrl,
+		mainEntity
+	};
+}

--- a/src/lib/utils/community-faq-seo.test.js
+++ b/src/lib/utils/community-faq-seo.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { htmlToPlainText, buildCommunityFaqJsonLd } from './community-faq-seo.js';
+
+describe('community-faq-seo', () => {
+	it('strips HTML for schema text', () => {
+		const plain = htmlToPlainText(
+			'<p>Hello <strong>world</strong>.</p><p>Second <a href="/x">link</a>.</p>'
+		);
+		expect(plain).toContain('Hello world.');
+		expect(plain).toContain('Second link.');
+		expect(plain).not.toContain('<');
+	});
+
+	it('builds FAQPage JSON-LD', () => {
+		const sections = [
+			{
+				id: 'test',
+				label: 'Test',
+				items: [{ id: 'one', question: 'Q1?', answer: '<p>A1</p>' }]
+			}
+		];
+		const json = buildCommunityFaqJsonLd(sections, 'https://zapstore.dev/community/faq');
+		expect(json['@type']).toBe('FAQPage');
+		expect(json.mainEntity).toHaveLength(1);
+		expect(json.mainEntity[0].name).toBe('Q1?');
+		expect(json.mainEntity[0].acceptedAnswer.text).toBe('A1');
+	});
+});

--- a/src/routes/community/+layout.svelte
+++ b/src/routes/community/+layout.svelte
@@ -73,6 +73,12 @@
 
 	let { children } = $props();
 
+	const FAQ_SECTION = {
+		id: 'faq',
+		label: 'FAQ',
+		href: '/community/faq'
+	};
+
 	const SECTIONS = COMMUNITY_FORUM_AND_ACTIVITY_ENABLED
 		? [
 				{
@@ -86,16 +92,18 @@
 					label: 'Activity',
 					icon: '/images/emoji/activity.png',
 					href: '/community/activity'
-				}
-		]
-	: [
-			{
-				id: 'support',
-				label: 'Support',
-				icon: '/images/emoji/activity.png',
-				href: '/community/support'
-			}
-		];
+				},
+				FAQ_SECTION
+			]
+		: [
+				{
+					id: 'support',
+					label: 'Support',
+					icon: '/images/emoji/activity.png',
+					href: '/community/support'
+				},
+				FAQ_SECTION
+			];
 
 	const defaultSectionId = COMMUNITY_FORUM_AND_ACTIVITY_ENABLED ? 'forum' : 'support';
 
@@ -121,7 +129,9 @@
 				? 'support'
 				: path.startsWith('/community/activity')
 					? 'activity'
-					: defaultSectionId
+					: path.startsWith('/community/faq')
+						? 'faq'
+						: defaultSectionId
 	);
 	const activeSectionLabel = $derived(
 		SECTIONS.find((s) => s.id === activeSection)?.label ??
@@ -157,6 +167,8 @@
 <svelte:head>
 	{#if path.startsWith('/community/support')}
 		<title>Support — Zapstore</title>
+	{:else if path.startsWith('/community/faq')}
+		<title>FAQ — Zapstore</title>
 	{/if}
 </svelte:head>
 

--- a/src/routes/community/faq/+page.js
+++ b/src/routes/community/faq/+page.js
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/src/routes/community/faq/+page.js
+++ b/src/routes/community/faq/+page.js
@@ -1,1 +1,3 @@
+/** SSR so title, meta, and FAQPage JSON-LD are in prerendered HTML (parent community layout is client-only). */
+export const ssr = true;
 export const prerender = true;

--- a/src/routes/community/faq/+page.svelte
+++ b/src/routes/community/faq/+page.svelte
@@ -1,0 +1,59 @@
+<script lang="js">
+	import SeoHead from '$lib/components/layout/SeoHead.svelte';
+	import FaqPage from '$lib/components/faq/FaqPage.svelte';
+	import { COMMUNITY_FAQ_SECTIONS } from '$lib/data/community-faq-content.js';
+	import { SITE_URL } from '$lib/config';
+</script>
+
+<SeoHead
+	title="FAQ — Zapstore"
+	description="Answers about installing Zapstore, app safety, trust signals, comparisons with other stores, features, and troubleshooting."
+	url="{SITE_URL}/community/faq"
+/>
+
+<div class="community-faq-scroll" data-main-scroll>
+	<div class="community-faq-page">
+		<h1 class="community-faq-title">FAQ</h1>
+		<p class="community-faq-lead text-muted-foreground">
+			Install, safety, comparisons, and everyday use. Publishing an app?
+			<a href="/docs/faq" class="community-faq-crosslink">See the Developer FAQ</a>.
+		</p>
+		<FaqPage sections={COMMUNITY_FAQ_SECTIONS} />
+	</div>
+</div>
+
+<style>
+	.community-faq-scroll {
+		flex: 1;
+		min-height: 0;
+		overflow-x: hidden;
+		overflow-y: auto;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	.community-faq-page {
+		padding: 1.5rem 1rem 2.5rem;
+		max-width: 42rem;
+		margin: 0 auto;
+	}
+
+	.community-faq-title {
+		font-size: 1.5rem;
+		font-weight: 650;
+		letter-spacing: -0.02em;
+		color: var(--white);
+		margin: 0 0 0.5rem;
+	}
+
+	.community-faq-lead {
+		font-size: 0.9375rem;
+		line-height: 1.5;
+		margin: 0 0 1.75rem;
+	}
+
+	.community-faq-crosslink {
+		color: var(--blurple, #7c6cff);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+</style>

--- a/src/routes/community/faq/+page.svelte
+++ b/src/routes/community/faq/+page.svelte
@@ -6,7 +6,7 @@
 	import { SITE_URL } from '$lib/config';
 
 	const faqUrl = `${SITE_URL}/community/faq`;
-	const seoTitle = 'Zapstore user FAQ: install, safety, F-Droid, Obtainium & troubleshooting';
+	const seoTitle = 'Zapstore FAQ: install, safety, F-Droid, Obtainium & troubleshooting';
 	const seoDescription =
 		'How to install Zapstore, stay safe with Web of Trust, compare with Google Play, F-Droid and Obtainium, use Stacks and zaps, and fix common update errors.';
 
@@ -17,7 +17,7 @@
 
 <div class="community-faq-scroll" data-main-scroll>
 	<div class="community-faq-page">
-		<h1 class="community-faq-title">User FAQ</h1>
+		<h1 class="community-faq-title">FAQ</h1>
 		<p class="community-faq-lead text-muted-foreground">
 			Install, safety, comparisons, and everyday use. Publishing an app?
 			<a href="/docs/faq" class="community-faq-crosslink">See the Developer FAQ</a>.

--- a/src/routes/community/faq/+page.svelte
+++ b/src/routes/community/faq/+page.svelte
@@ -2,18 +2,22 @@
 	import SeoHead from '$lib/components/layout/SeoHead.svelte';
 	import FaqPage from '$lib/components/faq/FaqPage.svelte';
 	import { COMMUNITY_FAQ_SECTIONS } from '$lib/data/community-faq-content.js';
+	import { buildCommunityFaqJsonLd } from '$lib/utils/community-faq-seo.js';
 	import { SITE_URL } from '$lib/config';
+
+	const faqUrl = `${SITE_URL}/community/faq`;
+	const seoTitle = 'Zapstore user FAQ: install, safety, F-Droid, Obtainium & troubleshooting';
+	const seoDescription =
+		'How to install Zapstore, stay safe with Web of Trust, compare with Google Play, F-Droid and Obtainium, use Stacks and zaps, and fix common update errors.';
+
+	const faqJsonLd = buildCommunityFaqJsonLd(COMMUNITY_FAQ_SECTIONS, faqUrl);
 </script>
 
-<SeoHead
-	title="FAQ — Zapstore"
-	description="Answers about installing Zapstore, app safety, trust signals, comparisons with other stores, features, and troubleshooting."
-	url="{SITE_URL}/community/faq"
-/>
+<SeoHead title={seoTitle} description={seoDescription} url={faqUrl} jsonld={faqJsonLd} />
 
 <div class="community-faq-scroll" data-main-scroll>
 	<div class="community-faq-page">
-		<h1 class="community-faq-title">FAQ</h1>
+		<h1 class="community-faq-title">User FAQ</h1>
 		<p class="community-faq-lead text-muted-foreground">
 			Install, safety, comparisons, and everyday use. Publishing an app?
 			<a href="/docs/faq" class="community-faq-crosslink">See the Developer FAQ</a>.

--- a/src/routes/docs/[...slug]/+page.svelte
+++ b/src/routes/docs/[...slug]/+page.svelte
@@ -1,12 +1,16 @@
 <script lang="js">
+import { page } from '$app/stores';
 import SeoHead from '$lib/components/layout/SeoHead.svelte';
+import { SITE_URL } from '$lib/config';
+
 let { data } = $props();
 let title = $derived(data.metadata?.title || 'Documentation');
 let description = $derived(data.metadata?.description || 'Zapstore documentation');
 let Content = $derived(data.content);
+const canonicalUrl = $derived(SITE_URL + $page.url.pathname);
 </script>
 
-<SeoHead title="{title} — Zapstore Documentation" {description} />
+<SeoHead title="{title} — Zapstore Documentation" {description} url={canonicalUrl} />
 
 <article class="prose max-w-none">
 	{#if data.metadata?.title}

--- a/src/routes/sitemap.xml/+server.js
+++ b/src/routes/sitemap.xml/+server.js
@@ -39,6 +39,7 @@ const STATIC_ROUTES = [
 	{ path: '/community', priority: '0.7', changefreq: 'weekly' },
 	{ path: '/community/forum', priority: '0.7', changefreq: 'daily' },
 	{ path: '/community/support', priority: '0.5', changefreq: 'monthly' },
+	{ path: '/community/faq', priority: '0.7', changefreq: 'monthly' },
 	{ path: '/blog', priority: '0.7', changefreq: 'weekly' },
 	{ path: '/docs', priority: '0.8', changefreq: 'weekly' },
 	{ path: '/assets', priority: '0.5', changefreq: 'yearly' },


### PR DESCRIPTION
## Summary

The site had a single FAQ at `/docs/faq` that mixed end-user and developer topics. This PR splits that into two audiences:

- **`/community/faq`** — User FAQ (install, safety, comparisons, features, troubleshooting, support). Primary entry: **Footer → Resources → FAQ**.
- **`/docs/faq`** — Developer FAQ (publishing, signing, trust model, relay issues, growth). Studio and docs links stay on this URL.

I walked through both pages locally and the copy/UI look good to me; I would appreciate a review before merge.

### What changed

- Rewrote [`src/content/docs/faq.md`](src/content/docs/faq.md) as a developer-focused FAQ with a link to the community FAQ.
- Added community FAQ route with accordion UI and content in [`src/lib/data/community-faq-content.js`](src/lib/data/community-faq-content.js).
- Added **FAQ** to the community sidebar; fixed scroll on the community FAQ page (`data-main-scroll`).
- Footer **Resources**: **FAQ** → `/community/faq`.
- Sitemap includes `/community/faq`.
- **SEO:** `FAQPage` JSON-LD ([`community-faq-seo.js`](src/lib/utils/community-faq-seo.js)), keyword-focused title/description, per-question `#anchors`, `h3` headings, `ssr = true` on the FAQ page so meta and schema are in prerendered HTML.

### Where the questions came from

User FAQ questions and answers were drafted from **recurring Nostr threads** (Zapstore account + community replies). Rewrote for clarity on the website.

Developer FAQ content aligns with existing docs (`publish`, `trust-model`) and developer-oriented items from that same research.

### Review requested

- @franzaps Please review FAQ **content** in general: accuracy, tone, anything misleading or missing (especially trust/safety and comparisons).
- @NielLiesmons Please review **design and frontend**: community FAQ layout, accordion spacing, community shell integration, footer/nav.

## Test plan

- [ ] `/community/faq` — sections render, accordions open/close, page scrolls inside community shell
- [ ] `/docs/faq` — developer topics only; link to community FAQ works
- [ ] Footer **User FAQ** → `/community/faq`
- [ ] Community sidebar **FAQ** highlights on `/community/faq`
- [ ] Cross-links: community FAQ ↔ developer FAQ; support / app page links
- [ ] View page source (or prerendered HTML): `FAQPage` JSON-LD and meta tags present
- [ ] `bun run build` passes
