### PR TITLE
Add SEO meta description to blog post

### DIFF
--- a/src/content/blog/building-a-different-kind-of-android-app-store/_index.md
+++ b/src/content/blog/building-a-different-kind-of-android-app-store/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Building a different kind of Android app store
-description: 
+description: The Zapstore blog is waking up with posts about app distribution, trust, developer publishing, community curation, and building an open Android app store.
 date: 2026-06-08
 draft: false
 ---


### PR DESCRIPTION
## Summary

Adds a `description` to the frontmatter of [Building a different kind of Android app store](/blog/building-a-different-kind-of-android-app-store) for meta tags, Open Graph, and Twitter cards.